### PR TITLE
qt6 compatibility

### DIFF
--- a/Spanish_Inspire_Catastral_Downloader.py
+++ b/Spanish_Inspire_Catastral_Downloader.py
@@ -42,14 +42,20 @@ try:
 except ImportError:
     None
 
-from PyQt5 import QtNetwork, uic
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+from qgis.PyQt import QtNetwork, uic
+from qgis.PyQt.QtCore import *
+from qgis.PyQt.QtGui import *
+from qgis.PyQt.QtWidgets import *
 from qgis.core import Qgis
+from .qt.get_qt_elements import *
 
-QT_VERSION = 5
-os.environ['QT_API'] = 'pyqt5'
+
+if QT_MAJOR == 5:
+    os.environ['QT_API'] = 'pyqt5'
+elif QT_MAJOR == 6:
+    os.environ['QT_API'] = 'pyqt6'
+else:
+    raise ValueError(f'QT_VERSION {QT_MAJOR} not supported')
 
 from qgis.core import *
 from qgis.core import (QgsMessageLog)
@@ -453,7 +459,7 @@ class Spanish_Inspire_Catastral_Downloader:
         self.dlg.show()
 
         # Run the dialog event loop
-        result = self.dlg.exec_()
+        result = exec_dialog(self.dlg)
 
         # See if OK was pressed
         if result: pass
@@ -554,7 +560,7 @@ class Spanish_Inspire_Catastral_Downloader:
         else:
             QgsMessageLog.logMessage("05 Inicio de descarga", 'SICD', level=Qgis.Info)
             try:
-                QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+                QApplication.setOverrideCursor(QCursor(WAIT_CURSOR))
                 inecode_catastro = self.dlg.comboBox_municipality.currentText()
 
                 zippath = self.dlg.lineEdit_path.text()

--- a/Spanish_Inspire_Catastral_Downloader_dialog.py
+++ b/Spanish_Inspire_Catastral_Downloader_dialog.py
@@ -28,17 +28,15 @@ import os
 
 try:
     from qgis.core import Qgis
-    from PyQt5.QtCore import *
-    from PyQt5.QtGui import *
-    from PyQt5.QtWidgets import *
-    from PyQt5 import uic
-    QT_VERSION=5
-    os.environ['QT_API'] = 'pyqt5'
+    from qgis.PyQt.QtCore import *
+    from qgis.PyQt.QtGui import *
+    from qgis.PyQt.QtWidgets import *
+    from qgis.PyQt import uic
+    from .qt.get_qt_elements import *
+    QT_VERSION=QT_MAJOR
+    os.environ['QT_API'] = f'pyqt{QT_MAJOR}'
 except:
-    from PyQt4.QtCore import *
-    from PyQt4.QtGui import *
-    from PyQt4 import uic
-    QT_VERSION=4
+    raise ValueError(f'QT_VERSION {QT_VERSION} not supported')
 
 import os.path
 from qgis.core import *

--- a/metadata.txt
+++ b/metadata.txt
@@ -9,7 +9,7 @@
 [general]
 name=Spanish Inspire Catastral Downloader
 qgisMinimumVersion=3.00
-qgisMaximumVersion=3.99
+qgisMaximumVersion=4.99
 description=Descarga de cartografía catastral según Inspire
 version=2.1
 author=Patricio Soriano :: SIGdeletras.com
@@ -54,4 +54,5 @@ experimental=False
 
 # deprecated flag (applies to the whole plugin, not just a single version)
 deprecated=False
+supportsQt6=True
 

--- a/qt/get_qt_elements.py
+++ b/qt/get_qt_elements.py
@@ -1,0 +1,27 @@
+
+from qgis.PyQt.QtCore import QT_VERSION_STR
+from qgis.PyQt.QtCore import Qt
+
+QT_MAJOR = int(QT_VERSION_STR.split(".", 1)[0])
+
+if QT_MAJOR >= 6:
+    SCROLLBAR_AS_NEEDED = Qt.ScrollBarPolicy.ScrollBarAsNeeded
+    SCROLLBAR_ALWAYS_OFF = Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+    SCROLLBAR_ALWAYS_ON = Qt.ScrollBarPolicy.ScrollBarAlwaysOn
+    CHECKED = Qt.CheckState.Checked
+    UNCHECKED = Qt.CheckState.Unchecked
+    PARTIALLY_CHECKED = Qt.CheckState.PartiallyChecked
+    WAIT_CURSOR = Qt.CursorShape.WaitCursor
+else:
+    SCROLLBAR_AS_NEEDED = Qt.ScrollBarAsNeeded
+    SCROLLBAR_ALWAYS_OFF = Qt.ScrollBarAlwaysOff
+    SCROLLBAR_ALWAYS_ON = Qt.ScrollBarAlwaysOn
+    CHECKED = Qt.Checked
+    UNCHECKED = Qt.Unchecked
+    PARTIALLY_CHECKED = Qt.PartiallyChecked
+    WAIT_CURSOR = Qt.CursorShape.WaitCursor
+
+# Exec compatibility with PyQt5 and PyQt6
+def exec_dialog(dialog):
+    # exec() funciona tanto en Qt 5 como en Qt 6
+    return dialog.exec()

--- a/resources.py
+++ b/resources.py
@@ -10,7 +10,7 @@ try:
     from PyQt5 import QtCore
 
 except:
-    from PyQt4 import QtCore
+    from PyQt6 import QtCore
 
 qt_resource_data = b"\
 \x00\x00\x08\x15\


### PR DESCRIPTION
- Usa dialog.exec() directamente (compatible con Qt 5 y Qt 6) - QGIS 3 y 4
- Añade constante WAIT_CURSOR para compatibilidad entre versiones
- Corrige AttributeError con exec_() en QGIS 4